### PR TITLE
Add extra arguments to the preventFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.2
+
+- update dependencies
+- added the event and delta arguments to the preventFunction method, as well as adding a onPreventDragging callback
+
 ## 1.2.1
 
 - update peerDependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -4127,8 +4127,7 @@
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",
     "rimraf": "^5.0.5",
-    "rollup": "^4.6.1",
-    "rollup-plugin-visualizer": "^5.9.3"
+    "rollup": "^4.7.0",
+    "rollup-plugin-visualizer": "^5.10.0"
   },
   "peerDependencies": {
     "@mapbox/mapbox-gl-draw": "^1.4.3"

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -2,7 +2,7 @@
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
 import * as Constants from '../constants.js';
 
-function patchDirectSelect(DirectSelect, preventFunction = () => true) {
+function patchDirectSelect(DirectSelect, preventFunction = () => true, onPreventDragging = () => undefined) {
   const DirectSelectPatched = { ...DirectSelect };
 
   DirectSelectPatched.clickInactive = function(state, e) {
@@ -21,7 +21,8 @@ function patchDirectSelect(DirectSelect, preventFunction = () => true) {
 
   DirectSelectPatched.dragFeature = function(state, e, delta) {
     const geojson = state.feature.toGeoJSON();
-    if (preventFunction(geojson)) {
+    if (preventFunction(geojson, e, delta)) {
+      onPreventDragging();
       // prevent dragging polygon/line features
       // noop
     } else {

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -36,7 +36,7 @@ function patchDirectSelect(DirectSelect, preventFunction = () => true, onPrevent
     const result = DirectSelect.onMouseMove.call(this, state, e);
 
     const geojson = state.feature.toGeoJSON();
-    if (preventFunction(geojson)) {
+    if (preventFunction(geojson, e, delta)) {
       // show pointer cursor on inactive features, move cursor on active feature vertices
       const isFeature = MapboxDraw.lib.CommonSelectors.isInactiveFeature(e);
       const onVertex = MapboxDraw.lib.CommonSelectors.isOfMetaType(Constants.meta.VERTEX)(e);


### PR DESCRIPTION
Include the event and delta parameters in the preventFunction method, and introduce an onPreventDragging callback to enable the prevention check using additional information.