### PR TITLE
Removed the extra delta argument passed to preventFunction on onMouseMove

### DIFF
--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -36,7 +36,7 @@ function patchDirectSelect(DirectSelect, preventFunction = () => true, onPrevent
     const result = DirectSelect.onMouseMove.call(this, state, e);
 
     const geojson = state.feature.toGeoJSON();
-    if (preventFunction(geojson, e, delta)) {
+    if (preventFunction(geojson, e)) {
       // show pointer cursor on inactive features, move cursor on active feature vertices
       const isFeature = MapboxDraw.lib.CommonSelectors.isInactiveFeature(e);
       const onVertex = MapboxDraw.lib.CommonSelectors.isOfMetaType(Constants.meta.VERTEX)(e);


### PR DESCRIPTION
Apologies, my previous PR introduced a bug: it passed a non-existing delta param on the onMouseMove method. This PR corrects it.

![image](https://github.com/zakjan/mapbox-gl-draw-waypoint/assets/2383329/be423f2b-0101-41c9-94e4-2725c1a4aca0)
